### PR TITLE
🐛 Filter only .xcodeproj from xcworkspace

### DIFF
--- a/RugbyPlanner/Modules/ProjectNavigator/Sevices/ProjectLoader/ProjectLoader.swift
+++ b/RugbyPlanner/Modules/ProjectNavigator/Sevices/ProjectLoader/ProjectLoader.swift
@@ -14,7 +14,7 @@ struct ProjectLoader {
     @Dependency(\.xcodeTargetsParser) var xcodeTargetsParser
 
     func load(workspace fileURL: URL) async throws -> [Project] {
-        let projectPaths = try xcodeWorkspaceReader.read(fileURL)
+        let projectPaths = try xcodeWorkspaceReader.readProjects(fileURL)
         let projectsInfo = try await xcodeProjectReader.read(projectPaths)
         let projects = await projectsInfo.concurrentMap {
             Project(name: $0.name, targets: xcodeTargetsParser.parse(project: $0.project))

--- a/RugbyPlanner/Modules/ProjectNavigator/Sevices/XcodeWorkspaceReader.swift
+++ b/RugbyPlanner/Modules/ProjectNavigator/Sevices/XcodeWorkspaceReader.swift
@@ -9,11 +9,11 @@ import Foundation
 import XcodeProj
 
 struct XcodeWorkspaceReader {
-    /// Returns: - Project paths.
-    func read(_ fileURL: URL) throws -> [URL] {
-        let workspace = try XCWorkspace(pathString: fileURL.path())
-        return workspace.data.children.map(\.location.path).map {
-            fileURL.deletingLastPathComponent().appending(path: $0)
-        }
+    func readProjects(_ fileURL: URL) throws -> [URL] {
+        try XCWorkspace(pathString: fileURL.path())
+            .data.children
+            .map(\.location.path)
+            .filter { $0.hasSuffix(".xcodeproj") }
+            .map { fileURL.deletingLastPathComponent().appending(path: $0) }
     }
 }


### PR DESCRIPTION
We need to skip all xcworkspace files except `.xcodeproj`.
If we don't do this, it will lead to error alert during parsing projects by urls.